### PR TITLE
Fix ml-api container port

### DIFF
--- a/elk-stack/ml-api/Dockerfile
+++ b/elk-stack/ml-api/Dockerfile
@@ -7,4 +7,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "5000"]
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- fix mismatch between `ml-api`'s exposed port and its Dockerfile

## Testing
- `python -m py_compile ml-api/app.py`
- `python -m pip install -r ml-api/requirements.txt`
- ❌ `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fadbe7334832791c8a9774d0c890e