### PR TITLE
Ensure ml API port is exposed

### DIFF
--- a/elk-stack/ml-api/Dockerfile
+++ b/elk-stack/ml-api/Dockerfile
@@ -7,4 +7,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
+EXPOSE 8000
+
 CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- expose port 8000 in ML API Dockerfile

## Testing
- `docker --version` *(fails: command not found)*
- `docker-compose --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683faf070a308327bd1e61afd806e9c4