### PR TITLE
Add basic FastAPI prediction test

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,20 @@
+name: Python Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r elk-stack/ml-api/requirements.txt
+        pip install pytest
+    - name: Run tests
+      run: pytest

--- a/elk-stack/ml-api/requirements.txt
+++ b/elk-stack/ml-api/requirements.txt
@@ -4,3 +4,4 @@ numpy
 onnxruntime
 scikit-learn
 joblib
+httpx<0.24

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+# Mock heavy dependencies before importing the app
+mock_session = MagicMock()
+mock_session.run.return_value = [[ [0.0, 1.0] ]]
+ort_mock = MagicMock()
+ort_mock.InferenceSession.return_value = mock_session
+sys.modules['onnxruntime'] = ort_mock
+
+class DummyScaler:
+    def transform(self, X):
+        import numpy as np
+        return np.array(X)
+
+joblib_mock = MagicMock()
+joblib_mock.load.return_value = DummyScaler()
+sys.modules['joblib'] = joblib_mock
+
+import numpy as np
+np.load = lambda *args, **kwargs: np.array(["class0", "class1"])
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'elk-stack' / 'ml-api'))
+
+from fastapi.testclient import TestClient
+from app import app
+
+client = TestClient(app)
+
+def test_predict_endpoint():
+    response = client.post('/predict', json={'log': {'Dst Port': 80}})
+    assert response.status_code == 200
+    data = response.json()
+    assert 'predicted_class' in data
+    assert 'class_name' in data


### PR DESCRIPTION
## Summary
- add pytest for `/predict` using TestClient
- configure GitHub Actions to run tests
- pin `httpx` version for compatibility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683faf08ba808327a11b9ee750da6c99