### PR TITLE
Handle prediction errors with HTTPException

### DIFF
--- a/elk-stack/ml-api/app.py
+++ b/elk-stack/ml-api/app.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 import onnxruntime as ort
 import numpy as np
@@ -49,4 +49,4 @@ async def predict(log_entry: LogEntry):
             "class_name": str(classes[predicted_class])
         }
     except Exception as e:
-        return {"error": str(e)}
+        raise HTTPException(status_code=500, detail=str(e))

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -34,3 +34,16 @@ def test_predict_endpoint():
     data = response.json()
     assert 'predicted_class' in data
     assert 'class_name' in data
+
+
+def test_predict_endpoint_error():
+    def raise_error(*args, **kwargs):
+        raise RuntimeError("fail")
+
+    mock_session.run.side_effect = raise_error
+    response = client.post('/predict', json={'log': {}})
+    assert response.status_code != 200
+    assert response.status_code == 500
+    data = response.json()
+    assert data.get('detail') == 'fail'
+    mock_session.run.side_effect = None


### PR DESCRIPTION
## Summary
- raise `HTTPException(status_code=500)` in `/predict`
- add test coverage for error responses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fbc7f98b48327af668c43109cceb1